### PR TITLE
DM-28237: Improve ATSpectrograph timeout handling

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -9,14 +9,8 @@ source:
 build:
   script: python -m pip install --no-deps --ignore-installed .
   script_env:
-    - PATH
-    - PYTHONPATH
-    - LD_LIBRARY_PATH
     - OSPL_HOME
-    - PYTHON_BUILD_VERSION
-    - PYTHON_BUILD_LOCATION
     - TS_CONFIG_LATISS_DIR
-    - LSST_DDS_DOMAIN
 
 test:
   requires:

--- a/doc/version-history.rst
+++ b/doc/version-history.rst
@@ -4,6 +4,24 @@
 Version History
 ===============
 
+v0.7.1
+------
+
+* Update setup.cfg to reformat code with black.
+* Update configuration schema to add timeout attributes.
+* Set timeout configuration to the model class.
+* Implement backward compatibility with previous xml file for sending new configuration values.
+* If connection fails during enable, disconnect before returning.
+* Add `begin_enable` method to send INPROGRESS acknowledgment.
+
+Requirements
+------------
+
+* xml >=7
+* salobj >6
+* ts_idl >2
+* ts_config_latiss >=0.6
+
 v0.7.0
 ------
 * Implement compatibility with xml 7.0.0.

--- a/schema/ATSpectrograph.yaml
+++ b/schema/ATSpectrograph.yaml
@@ -18,6 +18,22 @@ properties:
     decription: Port for the controller
     type: integer
     default: 9999
+  connection_timeout:
+    description: >-
+        How long to wait for a response from the low level controller when
+        establishing the connection (in seconds).
+    type: number
+    default: 60.
+  response_timeout:
+    description: >-
+      How long to wait for a response from low level controller when a command
+      or request is sent (in seconds).
+    type: number
+    default: 30.
+  move_timeout:
+    description: How long to wait for a movement (from wheels and/or linear stage) to complete (in seconds).
+    type: number
+    default: 60.
   min_pos:
     decription: Minimum position for the linear stage (in mm).
     type: number

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,20 +1,18 @@
-[aliases]
-test=pytest
-
 [flake8]
 max-line-length = 110
 max-doc-length = 79
-ignore = E133, E203, E226, E228, N802, N803, N806, N812, N813, N815, N816, W503
+ignore = E133, E226, E228, N802, N803, N806, N812, N813, N815, N816, W503
 exclude =
-  bin,
+  doc,
   doc/conf.py,
+  bin,
   **/*/__init__.py,
   **/*/version.py,
   tests/.tests
 
 [tool:pytest]
 addopts = --flake8
-flake8-ignore = E133 E203 E226 E228 N802 N803 N806 N812 N813 N815 N816 W503
+flake8-ignore = E133 E226 E228 N802 N803 N806 N812 N813 N815 N816 W503
 
 [metadata]
 version = attr: setuptools_scm.get_version


### PR DESCRIPTION
Update setup.cfg to reformat code with black.
Update configuration schema to add timeout configuration.
Set timeout configuration to the model class.
Implement backward compatibility with previous xml file for sending new configuration values.
If connection fails during enable, disconnect before returning.
Add `begin_enable` method to send INPROGRESS acknowledgment.